### PR TITLE
Add serial command args

### DIFF
--- a/nabu-adaptor-emu/requirements.txt
+++ b/nabu-adaptor-emu/requirements.txt
@@ -1,0 +1,4 @@
+# Required Python packages
+# pip install -r requirements.txt
+argparse
+pyserial


### PR DESCRIPTION
Adds the ability to specify serial port and baud rate via command line arguments

**Usage**
```python3 ./nabu-adaptor-emu.py --baudrate=111863 /dev/ttyUSB0```

* `ttyname` is mandatory
* `--baudrate` is optional - default is 111863 if not specified

Also adds `requirements.txt` for easy installation of dependencies